### PR TITLE
[AP-20]: implement in memory appointment repository

### DIFF
--- a/adapters/src/repositories/memory/appointment_memory_repository.py
+++ b/adapters/src/repositories/memory/appointment_memory_repository.py
@@ -1,0 +1,90 @@
+from dataclasses import replace
+from datetime import datetime, timedelta
+from typing import Dict, List, Optional
+from uuid import UUID, uuid4
+
+from core.src.exceptions.repository import RepositoryOperationException
+from core.src.models import Appointment
+
+
+class AppointmentRepository:
+    def __init__(self):
+        self.appointments: Dict[UUID, Appointment] = {}
+
+    async def create(self, appointment: Appointment) -> Appointment:
+        try:
+            if appointment.id is None:
+                appointment = replace(appointment, id=uuid4())
+            self.appointments[appointment.id] = appointment
+            return appointment
+        except Exception as e:
+            raise RepositoryOperationException("Appointment", "create", str(e))
+
+    async def get_by_id(self, appointment_id: UUID) -> Optional[Appointment]:
+        try:
+            return self.appointments.get(appointment_id)
+        except Exception as e:
+            raise RepositoryOperationException("Appointment", "get_by_id", str(e))
+
+    async def list(self) -> List[Appointment]:
+        try:
+            return list(self.appointments.values())
+        except Exception as e:
+            raise RepositoryOperationException("Appointment", "list", str(e))
+
+    async def get_by_doctor_id(self, doctor_id: UUID) -> List[Appointment]:
+        try:
+            return [
+                appointment
+                for appointment in self.appointments.values()
+                if appointment.doctor.id == doctor_id
+            ]
+        except Exception as e:
+            raise RepositoryOperationException(
+                "Appointment", "get_by_doctor_id", str(e)
+            )
+
+    async def get_by_patient_id(self, patient_id: UUID) -> List[Appointment]:
+        try:
+            return [
+                appointment
+                for appointment in self.appointments.values()
+                if appointment.patient.id == patient_id
+            ]
+        except Exception as e:
+            raise RepositoryOperationException(
+                "Appointment", "get_by_patient_id", str(e)
+            )
+
+    async def get_by_date_range(
+        self, start_date: datetime, end_date: datetime
+    ) -> List[Appointment]:
+        try:
+            return [
+                appointment
+                for appointment in self.appointments.values()
+                if start_date <= appointment.start_datetime < end_date
+            ]
+        except Exception as e:
+            raise RepositoryOperationException(
+                "Appointment", "get_by_date_range", str(e)
+            )
+
+    async def get_by_doctor_and_time_range(
+        self, doctor_id: UUID, start_time: datetime, end_time: datetime
+    ) -> List[Appointment]:
+        try:
+            return [
+                appointment
+                for appointment in self.appointments.values()
+                if appointment.doctor.id == doctor_id
+                and appointment.start_datetime < end_time
+                and (
+                    appointment.start_datetime + timedelta(minutes=appointment.duration)
+                )
+                > start_time
+            ]
+        except Exception as e:
+            raise RepositoryOperationException(
+                "Appointment", "get_by_doctor_and_time_range", str(e)
+            )

--- a/adapters/src/repositories/memory/appointment_memory_repository.py
+++ b/adapters/src/repositories/memory/appointment_memory_repository.py
@@ -5,10 +5,11 @@ from uuid import UUID, uuid4
 
 from core.src.exceptions.repository import RepositoryOperationException
 from core.src.models import Appointment
+from core.src.repositories.appointment_repository import AppointmentRepository
 
 
-class AppointmentRepository:
-    def __init__(self):
+class MemoryAppointmentRepository(AppointmentRepository):
+    def __init__(self) -> None:
         self.appointments: Dict[UUID, Appointment] = {}
 
     async def create(self, appointment: Appointment) -> Appointment:
@@ -20,13 +21,15 @@ class AppointmentRepository:
         except Exception as e:
             raise RepositoryOperationException("Appointment", "create", str(e))
 
-    async def get_by_id(self, appointment_id: UUID) -> Optional[Appointment]:
+    async def get_by_id(
+        self, appointment_id: UUID, include_inactive: bool = False
+    ) -> Optional[Appointment]:
         try:
             return self.appointments.get(appointment_id)
         except Exception as e:
             raise RepositoryOperationException("Appointment", "get_by_id", str(e))
 
-    async def list(self) -> List[Appointment]:
+    async def list(self, include_inactive: bool = False) -> List[Appointment]:
         try:
             return list(self.appointments.values())
         except Exception as e:

--- a/adapters/tests/repositories/memory/appointment/test_memory_create_appointment.py
+++ b/adapters/tests/repositories/memory/appointment/test_memory_create_appointment.py
@@ -1,0 +1,76 @@
+from typing import List
+from uuid import UUID, uuid4
+
+import pytest
+
+from adapters.src.repositories.memory.appointment_memory_repository import (
+    MemoryAppointmentRepository,
+)
+from core.src.exceptions.repository import RepositoryOperationException
+from core.src.models import Appointment
+
+
+async def test_create_appointment(
+    appointment_repository: MemoryAppointmentRepository,
+    sample_appointment_creation: Appointment,
+):
+    created_appointment = await appointment_repository.create(
+        sample_appointment_creation
+    )
+    assert created_appointment.id is not None
+    assert isinstance(created_appointment.id, UUID)
+
+    retrieved_schedule = await appointment_repository.get_by_id(created_appointment.id)
+    assert retrieved_schedule is not None
+    assert retrieved_schedule == created_appointment
+
+
+async def test_create_appointment_with_existing_id(
+    appointment_repository: MemoryAppointmentRepository,
+    sample_appointment: Appointment,
+):
+    existing_id = uuid4()
+    sample_appointment.id = existing_id
+
+    created_appointment = await appointment_repository.create(sample_appointment)
+    assert created_appointment.id == existing_id
+
+    retrieved_schedule = await appointment_repository.get_by_id(created_appointment.id)
+    assert retrieved_schedule is not None
+    assert retrieved_schedule == created_appointment
+
+
+async def test_create_multiple_appointments(
+    appointment_repository: MemoryAppointmentRepository,
+    sample_weekly_appointments: List[Appointment],
+):
+    created_appointments: List[Appointment] = []
+
+    for appointment in sample_weekly_appointments:
+        created_appointment = await appointment_repository.create(appointment)
+        created_appointments.append(created_appointment)
+
+    assert len(created_appointments) == len(sample_weekly_appointments)
+
+    for appointment in created_appointments:
+        assert appointment.id is not None
+        assert isinstance(appointment.id, UUID)
+
+    all_appointments = await appointment_repository.list()
+    assert len(all_appointments) == len(sample_weekly_appointments)
+    assert set(app.id for app in all_appointments) == set(
+        app.id for app in created_appointments
+    )
+
+
+async def test_repository_operation_exception_on_create(
+    appointment_repository: MemoryAppointmentRepository,
+    sample_appointment: Appointment,
+):
+    appointment_repository.appointments = None  # type: ignore
+
+    with pytest.raises(RepositoryOperationException) as exc_info:
+        await appointment_repository.create(sample_appointment)
+
+    assert "Appointment" in str(exc_info.value)
+    assert "create" in str(exc_info.value)

--- a/adapters/tests/repositories/memory/appointment/test_memory_list_appointments.py
+++ b/adapters/tests/repositories/memory/appointment/test_memory_list_appointments.py
@@ -1,0 +1,211 @@
+from dataclasses import replace
+from datetime import datetime, time, timedelta
+from typing import List
+from uuid import UUID, uuid4
+
+import pytest
+
+from adapters.src.repositories.memory.appointment_memory_repository import (
+    MemoryAppointmentRepository,
+)
+from core.src.exceptions.repository import RepositoryOperationException
+from core.src.models import Appointment, Doctor
+
+
+async def test_list_appointments(
+    appointment_repository: MemoryAppointmentRepository,
+    sample_weekly_appointments: List[Appointment],
+):
+    created_appointments = []
+    for appointment in sample_weekly_appointments:
+        created_appointment = await appointment_repository.create(appointment)
+        created_appointments.append(created_appointment)
+
+    appointments_list = await appointment_repository.list()
+
+    assert len(appointments_list) == len(sample_weekly_appointments)
+
+    for created_appointment in created_appointments:
+        assert created_appointment in appointments_list
+
+
+async def test_list_no_appointments(
+    appointment_repository: MemoryAppointmentRepository,
+):
+    appointments = await appointment_repository.list()
+    assert appointments == []
+
+
+async def test_list_get_by_doctor_id(
+    appointment_repository: MemoryAppointmentRepository,
+    sample_weekly_appointments: List[Appointment],
+):
+    created_appointments = []
+    for appointment in sample_weekly_appointments:
+        created_appointment = await appointment_repository.create(appointment)
+        created_appointments.append(created_appointment)
+
+    doctor_id = sample_weekly_appointments[0].doctor.id
+    appointments_list = await appointment_repository.get_by_doctor_id(doctor_id)
+
+    assert all(appointment.doctor.id == doctor_id for appointment in appointments_list)
+
+    assert len(appointments_list) == len(created_appointments)
+
+
+async def test_list_get_by_patient_id(
+    appointment_repository: MemoryAppointmentRepository,
+    sample_weekly_appointments: List[Appointment],
+):
+    created_appointments = []
+    for appointment in sample_weekly_appointments:
+        created_appointment = await appointment_repository.create(appointment)
+        created_appointments.append(created_appointment)
+
+    patient_id = sample_weekly_appointments[0].patient.id
+    appointments_list = await appointment_repository.get_by_patient_id(patient_id)
+
+    assert all(
+        appointment.patient.id == patient_id for appointment in appointments_list
+    )
+
+    assert len(appointments_list) == len(created_appointments)
+
+
+async def test_get_by_date_range(
+    appointment_repository: MemoryAppointmentRepository,
+    sample_weekly_appointments: List[Appointment],
+):
+    for appointment in sample_weekly_appointments:
+        await appointment_repository.create(appointment)
+
+    start_date = sample_weekly_appointments[1].start_datetime
+    end_date = sample_weekly_appointments[3].start_datetime + timedelta(hours=1)
+
+    appointments_in_range = await appointment_repository.get_by_date_range(
+        start_date, end_date
+    )
+
+    assert len(appointments_in_range) == 3
+    for appointment in appointments_in_range:
+        assert start_date <= appointment.start_datetime < end_date
+
+    exact_start = await appointment_repository.get_by_date_range(
+        sample_weekly_appointments[0].start_datetime,
+        sample_weekly_appointments[0].start_datetime + timedelta(minutes=1),
+    )
+    assert len(exact_start) == 1
+
+    exact_end = await appointment_repository.get_by_date_range(
+        sample_weekly_appointments[0].start_datetime,
+        sample_weekly_appointments[1].start_datetime,
+    )
+    assert len(exact_end) == 1
+
+
+async def test_get_by_doctor_and_time_range(
+    appointment_repository: MemoryAppointmentRepository,
+    sample_weekly_appointments: List[Appointment],
+    sample_doctor: Doctor,
+):
+    for appointment in sample_weekly_appointments:
+        await appointment_repository.create(appointment)
+
+    different_doctor = replace(
+        sample_doctor, id=UUID("12345678-1234-5678-1234-567812345678")
+    )
+    different_doctor_appointment = replace(
+        sample_weekly_appointments[2],
+        id=None,  # type: ignore
+        doctor=different_doctor,
+        start_datetime=sample_weekly_appointments[2].start_datetime
+        + timedelta(minutes=30),
+    )
+    await appointment_repository.create(different_doctor_appointment)
+
+    start_time = sample_weekly_appointments[1].start_datetime
+    end_time = sample_weekly_appointments[3].start_datetime + timedelta(hours=1)
+
+    appointments = await appointment_repository.get_by_doctor_and_time_range(
+        sample_doctor.id, start_time, end_time
+    )
+
+    assert len(appointments) == 3
+    for appointment in appointments:
+        assert appointment.doctor.id == sample_doctor.id
+        assert appointment.start_datetime < end_time
+        assert (
+            appointment.start_datetime + timedelta(minutes=appointment.duration)
+        ) > start_time
+
+    assert all(
+        appointment.id != different_doctor_appointment.id
+        for appointment in appointments
+    )
+
+
+async def test_repository_operation_exception_on_list(
+    appointment_repository: MemoryAppointmentRepository,
+):
+    appointment_repository.appointments = None  # type: ignore
+
+    with pytest.raises(RepositoryOperationException) as exc_info:
+        await appointment_repository.list()
+
+    assert "Appointment" in str(exc_info.value)
+    assert "list" in str(exc_info.value)
+
+
+async def test_repository_operation_exception_on_get_by_doctor_id(
+    appointment_repository: MemoryAppointmentRepository,
+):
+    appointment_repository.appointments = None  # type: ignore
+
+    with pytest.raises(RepositoryOperationException) as exc_info:
+        await appointment_repository.get_by_doctor_id(uuid4())
+
+    assert "Appointment" in str(exc_info.value)
+    assert "get_by_doctor_id" in str(exc_info.value)
+
+
+async def test_repository_operation_exception_on_get_by_patient_id(
+    appointment_repository: MemoryAppointmentRepository,
+):
+    appointment_repository.appointments = None  # type: ignore
+
+    with pytest.raises(RepositoryOperationException) as exc_info:
+        await appointment_repository.get_by_patient_id(uuid4())
+
+    assert "Appointment" in str(exc_info.value)
+    assert "get_by_patient_id" in str(exc_info.value)
+
+
+async def test_repository_operation_exception_on_get_by_date_range(
+    appointment_repository: MemoryAppointmentRepository,
+):
+    appointment_repository.appointments = None  # type: ignore
+
+    with pytest.raises(RepositoryOperationException) as exc_info:
+        await appointment_repository.get_by_date_range(
+            datetime.combine(datetime.now().date(), time(9, 0)),
+            datetime.combine(datetime.now().date(), time(9, 30)),
+        )
+
+    assert "Appointment" in str(exc_info.value)
+    assert "get_by_date_range" in str(exc_info.value)
+
+
+async def test_repository_operation_exception_on_get_by_doctor_and_time_range(
+    appointment_repository: MemoryAppointmentRepository,
+):
+    appointment_repository.appointments = None  # type: ignore
+
+    with pytest.raises(RepositoryOperationException) as exc_info:
+        await appointment_repository.get_by_doctor_and_time_range(
+            uuid4(),
+            datetime.combine(datetime.now().date(), time(9, 0)),
+            datetime.combine(datetime.now().date(), time(9, 30)),
+        )
+
+    assert "Appointment" in str(exc_info.value)
+    assert "get_by_doctor_and_time_range" in str(exc_info.value)

--- a/adapters/tests/repositories/memory/appointment/test_memory_retrieve_appointment.py
+++ b/adapters/tests/repositories/memory/appointment/test_memory_retrieve_appointment.py
@@ -1,0 +1,66 @@
+from uuid import uuid4
+
+import pytest
+
+from adapters.src.repositories.memory.appointment_memory_repository import (
+    MemoryAppointmentRepository,
+)
+from core.src.exceptions.repository import RepositoryOperationException
+from core.src.models import Appointment
+
+
+async def test_get_by_id(
+    appointment_repository: MemoryAppointmentRepository,
+    sample_appointment: Appointment,
+):
+    created_appointment = await appointment_repository.create(sample_appointment)
+    retrieved_appointment = await appointment_repository.get_by_id(
+        created_appointment.id
+    )
+
+    assert retrieved_appointment is not None
+
+    assert retrieved_appointment.doctor == sample_appointment.doctor
+    assert retrieved_appointment.patient == sample_appointment.patient
+    assert retrieved_appointment.start_datetime == sample_appointment.start_datetime
+    assert retrieved_appointment.duration == sample_appointment.duration
+    assert retrieved_appointment.status == sample_appointment.status
+
+    assert retrieved_appointment.id == created_appointment.id
+
+
+async def test_get_by_id_not_found(
+    appointment_repository: MemoryAppointmentRepository,
+):
+    appointment = await appointment_repository.get_by_id(uuid4())
+    assert appointment is None
+
+
+async def test_get_by_id_no_appointments(
+    appointment_repository: MemoryAppointmentRepository,
+):
+    appointment = await appointment_repository.get_by_id(uuid4())
+    assert appointment is None
+
+
+async def test_get_by_doctor_id(
+    appointment_repository: MemoryAppointmentRepository,
+    sample_appointment: Appointment,
+):
+    created_appointment = await appointment_repository.create(sample_appointment)
+    retrieved_appointment = await appointment_repository.get_by_doctor_id(
+        sample_appointment.doctor.id
+    )
+    assert retrieved_appointment == [created_appointment]
+
+
+async def test_repository_operation_exception_on_get_by_id(
+    appointment_repository: MemoryAppointmentRepository,
+):
+    appointment_repository.appointments = None  # type: ignore
+
+    with pytest.raises(RepositoryOperationException) as exc_info:
+        await appointment_repository.get_by_id(uuid4())
+
+    assert "Appointment" in str(exc_info.value)
+    assert "get_by_id" in str(exc_info.value)

--- a/conftest.py
+++ b/conftest.py
@@ -3,4 +3,5 @@ pytest_plugins = [
     "core.tests.fixtures.patient_fixtures",
     "core.tests.fixtures.specialty_fixtures",
     "core.tests.fixtures.doctor_fixtures",
+    "core.tests.fixtures.appointment_fixtures",
 ]

--- a/core/src/models/__init__.py
+++ b/core/src/models/__init__.py
@@ -1,5 +1,5 @@
 from .appointment import Appointment
-from .appointment_status import AppointmentStatus
+from .appointment_status import AppointmentStatus, AppointmentStatusEnum
 from .doctor import Doctor
 from .patient import Patient
 from .role import Role, RoleEnum
@@ -15,4 +15,5 @@ __all__ = [
     "Specialty",
     "Appointment",
     "AppointmentStatus",
+    "AppointmentStatusEnum",
 ]

--- a/core/src/models/__init__.py
+++ b/core/src/models/__init__.py
@@ -1,5 +1,17 @@
+from .appointment import Appointment
+from .appointment_status import AppointmentStatus
+from .doctor import Doctor
 from .patient import Patient
 from .role import Role, RoleEnum
 from .user import User
 
-__all__ = ["User", "Role", "Patient", "RoleEnum"]
+__all__ = [
+    "User",
+    "Role",
+    "Patient",
+    "RoleEnum",
+    "Doctor",
+    "Specialty",
+    "Appointment",
+    "AppointmentStatus",
+]

--- a/core/src/models/appointment.py
+++ b/core/src/models/appointment.py
@@ -1,28 +1,17 @@
-from datetime import date, time
-from typing import Optional
+from dataclasses import dataclass
+from datetime import datetime
+from uuid import UUID
 
-from pydantic import BaseModel, Field
+from .appointment_status import AppointmentStatus
+from .doctor import Doctor
+from .patient import Patient
 
 
-class Appointment(BaseModel):
-    id: Optional[int] = None
-    patient_id: int
-    doctor_id: int
-    appointment_date: date
-    start_time: time
-    duration: int = Field(..., gt=0)
-    status: str = Field(..., max_length=20)
-
-    model_config = {
-        "json_schema_extra": {
-            "example": {
-                "id": 1,
-                "patient_id": 1,
-                "doctor_id": 1,
-                "appointment_date": "2023-06-15",
-                "start_time": "14:30:00",
-                "duration": 30,
-                "status": "scheduled",
-            }
-        }
-    }
+@dataclass
+class Appointment:
+    id: UUID
+    doctor: Doctor
+    patient: Patient
+    start_datetime: datetime
+    duration: int
+    status: AppointmentStatus

--- a/core/src/models/appointment_status.py
+++ b/core/src/models/appointment_status.py
@@ -1,0 +1,15 @@
+from dataclasses import dataclass
+from enum import Enum
+from typing import Optional
+
+
+class AppointmentStatusEnum(Enum):
+    SCHEDULED = "Scheduled"
+    COMPLETED = "Completed"
+    CANCELLED = "Cancelled"
+
+
+@dataclass
+class AppointmentStatus:
+    name: AppointmentStatusEnum
+    id: Optional[int] = None

--- a/core/src/repositories/appointment_repository.py
+++ b/core/src/repositories/appointment_repository.py
@@ -1,6 +1,7 @@
 from abc import ABC, abstractmethod
-from datetime import date
+from datetime import datetime
 from typing import List
+from uuid import UUID
 
 from core.src.models.appointment import Appointment
 from core.src.repositories.base_repository import BaseRepository
@@ -8,11 +9,21 @@ from core.src.repositories.base_repository import BaseRepository
 
 class AppointmentRepository(BaseRepository[Appointment], ABC):
     @abstractmethod
-    async def get_by_doctor_and_date(
-        self, doctor_id: int, date: date
-    ) -> List[Appointment]:
-        pass
+    async def get_by_doctor_id(self, doctor_id: UUID) -> List[Appointment]:
+        raise NotImplementedError
 
     @abstractmethod
-    async def get_by_patient(self, patient_id: int) -> List[Appointment]:
-        pass
+    async def get_by_patient_id(self, patient_id: UUID) -> List[Appointment]:
+        raise NotImplementedError
+
+    @abstractmethod
+    async def get_by_date_range(
+        self, start_date: datetime, end_date: datetime
+    ) -> List[Appointment]:
+        raise NotImplementedError
+
+    @abstractmethod
+    async def get_by_doctor_and_time_range(
+        self, doctor_id: UUID, start_time: datetime, end_time: datetime
+    ) -> List[Appointment]:
+        raise NotImplementedError

--- a/core/tests/fixtures/appointment_fixtures.py
+++ b/core/tests/fixtures/appointment_fixtures.py
@@ -1,0 +1,71 @@
+from datetime import datetime, time, timedelta
+from typing import List
+from uuid import uuid4
+
+import pytest
+
+from adapters.src.repositories.memory.appointment_memory_repository import (
+    MemoryAppointmentRepository,
+)
+from core.src.models import (
+    Appointment,
+    AppointmentStatus,
+    AppointmentStatusEnum,
+    Doctor,
+    Patient,
+)
+
+
+@pytest.fixture
+async def appointment_repository() -> MemoryAppointmentRepository:
+    return MemoryAppointmentRepository()
+
+
+@pytest.fixture
+def sample_appointment_creation(
+    sample_doctor: Doctor, sample_patient: Patient
+) -> Appointment:
+    return Appointment(
+        id=None,  # type: ignore
+        doctor=sample_doctor,
+        patient=sample_patient,
+        start_datetime=datetime.combine(datetime.now().date(), time(9, 0)),  # 9:00 AM
+        duration=30,
+        status=AppointmentStatus(name=AppointmentStatusEnum.SCHEDULED),
+    )
+
+
+@pytest.fixture
+def sample_appointment(sample_doctor: Doctor, sample_patient: Patient) -> Appointment:
+    return Appointment(
+        id=uuid4(),
+        doctor=sample_doctor,
+        patient=sample_patient,
+        start_datetime=datetime.combine(datetime.now().date(), time(9, 0)),  # 9:00 AM
+        duration=30,
+        status=AppointmentStatus(name=AppointmentStatusEnum.SCHEDULED),
+    )
+
+
+@pytest.fixture
+def sample_weekly_appointments(
+    sample_doctor: Doctor, sample_patient: Patient
+) -> List[Appointment]:
+    base_date = datetime.now().date()
+    base_time = datetime.min.time().replace(hour=9)  # Start at 9 AM
+
+    appointments = []
+    for i in range(5):
+        start_datetime = datetime.combine(base_date, base_time) + timedelta(days=i)
+        appointments.append(
+            Appointment(
+                id=None,  # type: ignore
+                doctor=sample_doctor,
+                patient=sample_patient,
+                start_datetime=start_datetime,
+                duration=30,
+                status=AppointmentStatus(name=AppointmentStatusEnum.SCHEDULED),
+            )
+        )
+
+    return appointments


### PR DESCRIPTION
## Description

Why?:

- To enable development and testing of appointment features without a database
- To provide a flexible, in-memory solution for storing and retrieving appointment data

Key changes:

- Implemented InMemoryAppointmentRepository with create, get by id, and list operations
- Added methods to filter appointments by get by doctor id, patient id, by date range and (by doctor and time range)
- Created unit tests for all repository methods
- Updated core models and interfaces to support the new repository


## Ticket:
- [AP-20](https://x-gabriela.atlassian.net/browse/AP-20)

## Type of change

- [X] New feature

## How Has This Been Tested?

- Unit tests have been added for all repository methods in:

  - test_memory_create_appointment.py
  - test_memory_list_appointments.py
  - test_memory_retrieve_appointment.py

- All tests are passing locally:
![imagen](https://github.com/user-attachments/assets/748b1cac-0339-4656-ae3b-8891833fd3aa)

## Checklist:

- [X] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes


[AP-20]: https://x-gabriela.atlassian.net/browse/AP-20?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ